### PR TITLE
[Bugfix] getCommands

### DIFF
--- a/src/Totem.php
+++ b/src/Totem.php
@@ -85,6 +85,11 @@ class Totem
             }
 
             return $name;
+        })->map(function($command){
+            return [
+                'name' => $command->getName(),
+                'description' => $command->getDescription()
+            ];
         });
     }
 


### PR DESCRIPTION
getCommands was returning a collection of command objects with protected values, this collection was then passed to the view , which used accessors to retrieve the values.

After a recent change to the the view file,  this collection is now json_encoded and passed to a vue template.

Unfortunately, this resulted in an array with keys but empty values.

By adding ->map after the sorting I am returning an array which can be properly json_encoded and passed to the vue template